### PR TITLE
Use conventional comments to avoid string concatenation.

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,10 +1,8 @@
+# enable CSRF
 WTF_CSRF_ENABLED = True
-""" enable CSRF
-"""
 
+# secret key for authentication
 SECRET_KEY = 'you-will-never-guess'
-""" secret key for authentication
-"""
 
 PYLTI_CONFIG = {
     "consumers":{
@@ -12,12 +10,10 @@ PYLTI_CONFIG = {
     }
 }
 
+# Remap URL to fix edX's misrepresentation of https protocol.
+# You can add another dict entry if you have trouble with the
+# PyLti URL.
 PYLTI_URL_FIX = {
-""" Remap URL to fix edX's misrepresentation of https protocol.
-    You can add another dict entry if you have trouble with the
-    PyLti URL.
-"""
-
     "https://localhost:8000/": {
         "https://localhost:8000/": "http://localhost:8000/"
     },


### PR DESCRIPTION
The old way concatenated string literals, borking the first key.
