### PR TITLE
Display exception in error template

### DIFF
--- a/mit_lti_flask_sample.py
+++ b/mit_lti_flask_sample.py
@@ -30,7 +30,7 @@ def error(exception=None):
     :param exception: optional exception
     :return: the error.html template rendered
     """
-    return render_template('error.html')
+    return render_template('error.html', exception=exception)
 
 
 @app.route('/is_up', methods=['GET'])

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,1 +1,7 @@
-There was an error
+There was an error.
+
+{% if exception and exception.exception %}
+<blockquote>
+    Exception: {{exception.exception}}
+</blockquote>
+{% endif %}


### PR DESCRIPTION
When setting this flask app up on heroku, I got the
error, "This page requires a valid oauth session or request". It would
be nice to display this error in the error template as well as the logs,
since this app is just intended to be an example for messing around with
LTI.