### PR TITLE
Update uWSGI version to 2.0.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ httplib2==0.9
 itsdangerous==0.24
 oauth==1.0.1
 oauth2==1.9.0.post1
-uWSGI==2.0.7
+uWSGI==2.0.13
 urwid==1.2.1
 wsgiref==0.1.2
 Sphinx==1.2.3


### PR DESCRIPTION
Heroku installation fails on uWSGI, with [this error](https://pastebin.com/nM943HkB).  If we update uWSGI to 2.0.13 in requirements.txt then it works.